### PR TITLE
Machine Specifications added to SpecWatchr

### DIFF
--- a/dotnet.watchr.rb
+++ b/dotnet.watchr.rb
@@ -23,7 +23,7 @@ The default behavior: specwatchr will look for a file called Rakefile.rb, if it
 finds one then it will automatically set the builder to rake builder
 =end
 
-config = { :builder => :MSBuilder, :test_runner => :MSPECTestRunner }
+config = { :builder => :MSBuilder, :test_runner => :NSpecRunner }
 
 config[:builder] = :RakeBuilder if File.exists? "Rakefile.rb" #specwatchr will use :RakeBuilder if it finds Rakefile.rb
 

--- a/dotnet.watchr.rb
+++ b/dotnet.watchr.rb
@@ -98,7 +98,7 @@ if you choose :MSPECTestRunner as your :test_runner
 this is the execution path for mspec-clr4.exe
 =end
 MSPECTestRunner.mspec_path = 
-  '.\packages\Machine.Specifications.0.5.12\tools\mspec-clr4.exe'
+  'packages\Machine.Specifications.0.5.12\tools\mspec-clr4.exe'
 
 
 =begin

--- a/dotnet.watchr.rb
+++ b/dotnet.watchr.rb
@@ -23,7 +23,7 @@ The default behavior: specwatchr will look for a file called Rakefile.rb, if it
 finds one then it will automatically set the builder to rake builder
 =end
 
-config = { :builder => :MSBuilder, :test_runner => :NSpecRunner }
+config = { :builder => :MSBuilder, :test_runner => :MSPECTestRunner }
 
 config[:builder] = :RakeBuilder if File.exists? "Rakefile.rb" #specwatchr will use :RakeBuilder if it finds Rakefile.rb
 
@@ -84,6 +84,22 @@ this is the execution path for MSTest.exe
 =end
 MSTestRunner.ms_test_path = 
   'C:\program files (x86)\microsoft visual studio 10.0\common7\ide\mstest.exe'
+
+=begin
+ _______  _______  _______  _______  _______ 
+(       )(  ____ \(  ____ )(  ____ \(  ____ \
+| () () || (    \/| (    )|| (    \/| (    \/
+| || || || (_____ | (____)|| (__    | |      
+| |(_)| |(_____  )|  _____)|  __)   | |      
+| |   | |      ) || (      | (      | |      
+| )   ( |/\____) || )      | (____/\| (____/\
+|/     \|\_______)|/       (_______/(_______/
+if you choose :MSPECTestRunner as your :test_runner
+this is the execution path for mspec-clr4.exe
+=end
+MSPECTestRunner.mspec_path = 
+  '.\packages\Machine.Specifications.0.5.12\tools\mspec-clr4.exe'
+
 
 =begin
  _                 _       __________________

--- a/dotnet.watchr.rb
+++ b/dotnet.watchr.rb
@@ -98,7 +98,7 @@ if you choose :MSPECTestRunner as your :test_runner
 this is the execution path for mspec-clr4.exe
 =end
 MSPECTestRunner.mspec_path = 
-  'packages\Machine.Specifications.0.5.12\tools\mspec-clr4.exe'
+  'packages\Machine.Specifications.0.5.15\tools\mspec-clr4.exe'
 
 
 =begin

--- a/spec/describe_MSpecRunner/describe_output_formatting_spec.rb
+++ b/spec/describe_MSpecRunner/describe_output_formatting_spec.rb
@@ -1,0 +1,379 @@
+require "./watcher_dot_net.rb"
+
+describe MSPECTestRunner do
+  before(:each) do 
+    @sh = mock("CommandShell")
+    CommandShell.stub!(:new).and_return(@sh)
+    @test_runner = MSPECTestRunner.new "." 
+    $stdout.stub!(:puts) { }
+    @sh.stub!(:execute).and_return("")
+    @test_runner.stub!(:test_dlls).and_return(["./test1.dll"])
+  end
+
+  describe "output formatting" do
+    context "is : \"No tests to execute\"" do
+      it "should return no specs found" do
+        expected_output = <<-OUTPUT.gsub(/^ {10}/, '')
+          Test Inconclusive:
+          No tests found under SomeTestSpec
+
+        OUTPUT
+
+        given_output "./test1.dll", "No tests to execute"
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.test_results.should == expected_output
+      end
+    end
+
+    context "has failing tests" do
+      context "single behavioral test under spec" do
+        it "should format test output with a little clean up" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            Failed Tests:
+            autotestnet.when_failing_test.it_should_fail_first_test
+            Exception occured on following line
+
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+            Exception occured on following line
+          console
+
+          given_output "./test1.dll", console_output
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+
+        it "should find name of test regardless of how many spaces exist between name and Failed entry" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            Failed Tests:
+            autotestnet.when_failing_test.it_should_fail_first_test
+            Exception occured on following line
+
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_failing_test.it_should_fail_first_test                                (FAIL)
+            Exception occured on following line
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+
+        it "should set first_failed_test" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            Failed Tests:
+            autotestnet.when_failing_test.it_should_fail_first_test
+            Exception occured on following line
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+            Exception occured on following line
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == true
+          @test_runner.first_failed_test.should == expected_output 
+        end
+
+        context "multi line error message" do
+          it "should include multi line error message" do
+            expected_output = <<-output.gsub(/^ {14}/, '')
+              Failed Tests:
+              autotestnet.when_failing_test.it_should_fail_first_test
+              Exception occured on following line
+              line 2
+
+              autotestnet.when_failing_test.it_should_fail_first_test2
+              Exception occured on following line
+              another lines of error
+              yet some more
+
+            output
+
+            console_output = <<-console.gsub(/^ {14}/, '')
+              gibberish
+              autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+              Exception occured on following line
+              line 2
+              should autotestnet.when_passing.it_should_pass
+              autotestnet.when_failing_test.it_should_fail_first_test2 (FAIL)
+              Exception occured on following line
+              another lines of error
+              yet some more
+              should autotestnet.when_passing.it_should_pass
+            console
+
+            given_output "./test1.dll", console_output
+
+            @test_runner.execute "SomeTestSpec"
+            @test_runner.test_results.should == expected_output
+          end
+        end
+      end
+    end
+
+    context "has passed tests" do
+      context "single behavioral test under spec" do
+        it "should format test output with a little cleanup" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            All Passed:
+            autotestnet.when_passing_test.it_should_pass_first_test
+
+            autotestnet.when_passing_test.it_should_pass_second_test
+
+            2 tests ran and passed
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_passing_test.it_should_pass_first_test
+            autotestnet.when_passing_test.it_should_pass_second_test
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+
+        it "should find named of passing test name regardless of how many lines are between Passed marker and test name" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            All Passed:
+            autotestnet.when_passing_test.it_should_pass_first_test
+
+            autotestnet.when_passing_test.it_should_pass_second_test
+
+            2 tests ran and passed
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_passing_test.it_should_pass_first_test
+            autotestnet.when_passing_test.it_should_pass_second_test
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+
+        it "disregards the Passed word in the summary section" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            All Passed:
+            autotestnet.when_passing_test.it_should_pass_first_test
+
+            1 tests ran and passed
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_passing_test.it_should_pass_first_test
+            Summary
+            ========
+                Passed     1
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+      end
+
+      context "multiple behavioral tests under spec" do
+        it "should format test output with nice tabs" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            All Passed:
+            autotestnet.when_passing_test.it_should_pass_first_test
+
+            autotestnet.when_passing_test.it_should_pass_second_test
+
+            autotestnet.when_passing_other_test.it_should_pass_other_test
+
+            3 tests ran and passed
+          output
+
+          console_output = <<-console.gsub(/^ {12}/, '')
+            autotestnet.when_passing_test.it_should_pass_first_test
+            autotestnet.when_passing_test.it_should_pass_second_test
+            autotestnet.when_passing_other_test.it_should_pass_other_test
+          console
+
+          given_output "./test1.dll", console_output
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+        end
+      end
+    end
+
+    context "multiple dlls" do
+      before { @test_runner.stub!(:test_dlls).and_return(["./test1.dll", "./test2.dll"]) }
+        
+
+      it "should only show failed test output even if another dll has all tests passed" do
+        expected_output = <<-output.gsub(/^ {10}/, '')
+          Failed Tests:
+          autotestnet.when_failing_test.it_should_fail_first_test
+
+          autotestnet.when_failing_test.it_should_fail_second_test
+
+        output
+
+        console_output_dll1 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_passing_other_test.it_should_pass_other_test
+        console
+
+        console_output_dll2 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+          autotestnet.when_failing_test.it_should_fail_second_test (FAIL)
+        console
+
+        given_output "./test1.dll", console_output_dll1
+        given_output "./test2.dll", console_output_dll2
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.test_results.should == expected_output
+      end
+
+      it "should aggregate output of both failing test executions" do
+        expected_output = <<-output.gsub(/^ {10}/, '')
+          Failed Tests:
+          autotestnet.when_failing_other_test.it_should_fail_other_test
+
+          Failed Tests:
+          autotestnet.when_failing_test.it_should_fail_first_test
+
+          autotestnet.when_failing_test.it_should_fail_second_test
+
+        output
+
+        console_output_dll1 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_failing_other_test.it_should_fail_other_test (FAIL)
+        console
+
+        console_output_dll2 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+          autotestnet.when_failing_test.it_should_fail_second_test (FAIL)
+        console
+
+        given_output "./test1.dll", console_output_dll1
+        given_output "./test2.dll", console_output_dll2
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.test_results.should == expected_output
+      end
+
+      it "should set first_failed_test from first executed dll" do
+        expected_output = <<-output.gsub(/^ {10}/, '')
+          Failed Tests:
+          autotestnet.when_failing_other_test.it_should_fail_other_test
+          Exception occured on following line
+
+          Failed Tests:
+          autotestnet.when_failing_test.it_should_fail_first_test
+
+          autotestnet.when_failing_test.it_should_fail_second_test
+
+        output
+
+        console_output_dll1 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_failing_other_test.it_should_fail_other_test (FAIL)
+          Exception occured on following line
+        console
+
+        console_output_dll2 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_failing_test.it_should_fail_first_test (FAIL)
+          autotestnet.when_failing_test.it_should_fail_second_test (FAIL)
+        console
+
+        given_output "./test1.dll", console_output_dll1
+        given_output "./test2.dll", console_output_dll2
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.first_failed_test.should == <<-expected.gsub(/^ {10}/, '')
+          Failed Tests:
+          autotestnet.when_failing_other_test.it_should_fail_other_test
+          Exception occured on following line
+        expected
+      end
+
+      it "should aggregate output of both passing test executions" do
+        expected_output = <<-output.gsub(/^ {10}/, '')
+          All Passed:
+          autotestnet.when_passing_other_test.it_should_pass_other_test
+
+          All Passed:
+          autotestnet.when_passing_test.it_should_pass_first_test
+
+          autotestnet.when_passing_test.it_should_pass_second_test
+          
+          3 tests ran and passed
+        output
+
+        console_output_dll1 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_passing_other_test.it_should_pass_other_test
+        console
+
+        console_output_dll2 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_passing_test.it_should_pass_first_test
+          autotestnet.when_passing_test.it_should_pass_second_test
+        console
+
+        given_output "./test1.dll", console_output_dll1
+        given_output "./test2.dll", console_output_dll2
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.test_results.should == expected_output
+      end
+
+      it "should summarize number of passed tests on last line" do
+        expected_output = "3 tests ran and passed"
+
+        console_output_dll1 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_passing_other_test.it_should_pass_other_test
+        console
+
+        console_output_dll2 = <<-console.gsub(/^ {10}/, '')
+          autotestnet.when_passing_test.it_should_pass_first_test
+          autotestnet.when_passing_test.it_should_pass_second_test
+        console
+
+        given_output "./test1.dll", console_output_dll1
+        given_output "./test2.dll", console_output_dll2
+
+        @test_runner.execute "SomeTestSpec"
+        @test_runner.test_results.split("\n").last.should == expected_output
+      end
+
+      it "should aggregate output of both inconclusive test executions" do
+          expected_output = <<-output.gsub(/^ {12}/, '')
+            Test Inconclusive:
+            No tests found under SomeTestSpec
+
+            Test Inconclusive:
+            No tests found under SomeTestSpec
+
+          output
+
+          given_output "./test1.dll", "No tests to execute" 
+          given_output "./test2.dll", "No tests to execute"
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.test_results.should == expected_output
+      end
+    end
+    
+    def given_output(dll_name, output)
+      @test_runner.stub!(:test_cmd).with(dll_name, "SomeTestSpec").and_return(dll_name)
+      @sh.stub!(:execute).with(dll_name).and_return(output)
+    end
+  end
+end

--- a/spec/describe_MSpecRunner/when_executing_tests_spec.rb
+++ b/spec/describe_MSpecRunner/when_executing_tests_spec.rb
@@ -1,0 +1,99 @@
+require "./watcher_dot_net.rb"
+
+describe MSPECTestRunner do
+  before(:each) do 
+    @sh = mock("CommandShell")
+    @sh.stub!(:execute).and_return("")
+    CommandShell.stub!(:new).and_return(@sh)
+    @test_runner = MSPECTestRunner.new "." 
+    $stdout.stub!(:puts) { }
+  end
+
+  describe "when executing tests (test statuses)" do
+    context "one test dll" do
+      before(:each) { @test_runner.stub!(:test_dlls).and_return(["./test1.dll"]) }
+      
+      context "given output is: No tests to execute" do
+        it "should mark test run as inconclusive" do
+          given_output "./test1.dll", "No tests to execute"
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.inconclusive.should == true
+        end
+      end
+
+      context "given output contains failing tests" do
+        it "should mark test run as failed" do
+          given_output "./test1.dll", "Failed    SomeTest.when_testing.should_fail"
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == true
+        end
+      end
+
+      context "given output contains no failing tests" do
+        it "should mark test run as passed" do
+          given_output "./test1.dll", "Passed    SomeTest.when_testing.should_pass"
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == false
+          @test_runner.inconclusive.should == false
+        end
+      end
+    end 
+
+    context "multiple tests dlls" do
+      before(:each) { @test_runner.stub!(:test_dlls).and_return(["./test1.dll", "./test2.dll"]) }
+
+      it "should execute tests against each dll" do
+        @sh.should_receive(:execute).twice()
+        @test_runner.execute "SomeTestSpec"
+      end
+
+      context "given output is: \"No tests to execute\" for both executions" do
+        it "should mark test run as inconclusive" do
+          given_output "./test1.dll", "No tests to execute"
+          given_output "./test2.dll", "No tests to execute"
+          
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.inconclusive.should == true
+        end
+      end
+
+      context "given failures exist for at least on dll" do
+        it "should mark test run as failed" do
+          given_output "./test1.dll", "Failed    when_testing.should_fail"
+          given_output "./test2.dll", "No tests to execute"
+
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == true
+        end
+      end
+
+      context "given a test suite ran with no failures" do
+        it "should mark test run as passed" do
+          given_output "./test1.dll", "Passed    when_testing.should_pass"
+          given_output "./test2.dll", "Passed    when_testing.should_pass_1"
+          
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == false
+          @test_runner.inconclusive.should == false
+        end
+
+        it "should ignore inconclusive runs and pass" do
+          given_output "./test1.dll", "Passed    when_testing.should_pass"
+          given_output "./test2.dll", "No tests to execute"
+          
+          @test_runner.execute "SomeTestSpec"
+          @test_runner.failed.should == false
+          @test_runner.inconclusive.should == false
+        end
+      end
+    end
+
+    def given_output(dll_name, output)
+      @test_runner.stub!(:test_cmd).with(dll_name, "SomeTestSpec").and_return(dll_name)
+      @sh.stub!(:execute).with(dll_name).and_return(output)
+    end
+  end
+end

--- a/spec/describe_MSpecRunner/when_initializing_MSpecRunner_spec.rb
+++ b/spec/describe_MSpecRunner/when_initializing_MSpecRunner_spec.rb
@@ -1,0 +1,30 @@
+require './watcher_dot_net.rb'
+
+describe MSPECTestRunner do
+  before(:each) do 
+    @test_runner = MSPECTestRunner.new "." 
+    $stdout.stub!(:puts) { }
+  end
+  
+  context "initializing MSPECTestRunner" do
+    it "should default machine specifications runner to the package location" do
+      MSPECTestRunner.mspec_path.should == ".\\packages\\Machine.Specifications.0.5.12\\tools\\mspec-clr4.exe"
+    end
+  end
+
+  describe "finding test_config" do
+    it "should find test config file named Local.testsettings" do
+      given_test_config "./Local.testsettings"
+      @test_runner.test_config.should == "Local.testsettings"
+    end
+
+    it "should find test config file named LocalTestRun.testrunconfig" do
+      given_test_config "./LocalTestRun.testrunconfig"
+      @test_runner.test_config.should == "LocalTestRun.testrunconfig"
+    end
+
+    def given_test_config file_name
+      Find.stub!(:find).with(".").and_yield(file_name)
+    end
+  end
+end

--- a/watcher_dot_net.rb
+++ b/watcher_dot_net.rb
@@ -724,7 +724,7 @@ class MSPECTestRunner < TestRunner
     @sh = CommandShell.new
     @failed_tests = Array.new
     @status_by_dll = Hash.new
-    @@mspec_path = ".\\packages\\Machine.Specifications.0.5.12\\tools\\mspec-clr4.exe"
+    @@mspec_path = "packages\\Machine.Specifications.0.5.12\\tools\\mspec-clr4.exe"
   end
 
   def self.mspec_path

--- a/watcher_dot_net.rb
+++ b/watcher_dot_net.rb
@@ -2,7 +2,7 @@
 #http://www.github.com/amirrajan/specwatchr
 #Copyright (c) 2011 Amir Rajan, Matt Florence
 #Copyright (c) 2011 The NSpec Development Team
-
+require 'pry'
 class GrowlNotifier
   def self.growl_path
     @@growl_path
@@ -89,7 +89,7 @@ class RakeBuilder
   def initialize folder
     @sh = CommandShell.new
     @failed = false
-    @folder = folder
+            @folder = folder
     @@rake_command = "rake"
   end
 
@@ -716,6 +716,202 @@ OUTPUT
   end 
   
 end
+
+class MSPECTestRunner < TestRunner
+  attr_accessor :failed, :inconclusive, :test_results
+  
+  def initialize folder
+    super folder
+    @sh = CommandShell.new
+    @failed_tests = Array.new
+    @status_by_dll = Hash.new
+    @@mspec_path = ".\\packages\\Machine.Specifications.0.5.12\\tools\\mspec-clr4.exe"
+  end
+
+  def self.mspec_path
+     @@mspec_path
+  end
+
+  def self.mspec_path= value
+    @@mspec_path = value
+  end
+  
+  def usage
+    <<-OUTPUT
+MSPECTestRunner will use the following exe to run your tests: 
+#{MSPECTestRunner.mspec_path}
+
+MSPECTestRunner for SpecWatchr uses a convension based approach for running unit tests.  Let's say you have a class called Person (located in file Person.cs).  You'll need to create a test class called describe_Person.cs (all tests associated with Person.cs should go under describe_Person.cs).  Once the test class is created, change the namespace of the class to include PersonSpec.  For example:
+
+//here is the person class (located in Person.cs)
+public class Person 
+{
+    public string FirstName { get; set; }
+}
+
+//here is the test class (located in describe_Person.cs)...notice the namespace
+namespace YourUnitTests.describe_Person
+{
+    public class when_initializing_person
+    {
+        Establish context = () =>{
+        };
+
+        Because of = () =>{
+          Person person = new Person();
+        };
+
+        It should = () =>{
+          person.FirstName.ShouldBeEmpty();
+        };
+    }
+}
+
+Whenever you save Person.cs, all tests under the namespace describe_Person will get executed.
+OUTPUT
+  end
+
+  def failed_tests
+    @failed_tests
+  end
+
+  def status_by_dll
+    @status_by_dll
+  end
+
+  def passed_tests
+    @passed_tests
+  end
+
+  def test_config
+    Find.find(@folder) do |f| 
+      return f.gsub("./", "") if /Local.testsettings$/.match(f) != nil || /LocalTestRun.testrunconfig$/.match(f) != nil
+    end
+  end
+
+  def set_test_status test_dll, test_output
+    results = Hash.new
+    results[:failed] = false
+    results[:inconclusive] = false
+
+    test_output.each_line do |output| 
+      results[:failed] = true if [/fail/i].any? { |pattern| output.match(pattern) }
+      results[:inconclusive] = true if output.match(/No tests to execute/)
+    end
+
+    @status_by_dll[test_dll] = results
+  end
+
+  def parse_test_result test_dll, test_output, test_name
+    last_test_item = nil
+    in_error = false
+    specification_name = nil
+    test_output.split("\n").each do |line|
+      stripped_line = line
+        if(line.match(/^when/i))
+            specification_name = stripped_line
+        elsif(line.match(/fail/i))
+          in_error = true
+          last_test_item = { :name => "#{specification_name}" + stripped_line.gsub(" (FAIL)", "").gsub(" ", ""), :dll => test_dll }
+          @failed_tests << last_test_item
+          last_test_item[:errormessage] = ""
+        elsif(line.match(/should/i))
+          in_error = false
+          last_test_item = { :name => "#{specification_name}" + stripped_line.gsub(" (FAIL)", "").gsub(" ", ""), :dll => test_dll }
+          @passed_tests << last_test_item
+        elsif(in_error)
+          if not(stripped_line.to_s.empty?)
+            last_test_item[:errormessage] += stripped_line + "\n" if last_test_item[:errormessage]
+          end
+        end
+    end
+
+    @failed_tests.sort! { |a, b| a[:spec] <=> b[:spec] }
+    @passed_tests.sort! { |a, b| a[:spec] <=> b[:spec] }
+  end
+
+  def set_test_result_output test_dll, test_name
+    tests = Array.new
+    failed = @status_by_dll[test_dll][:failed]
+    inconclusive = @status_by_dll[test_dll][:inconclusive]
+    passed = !failed && !inconclusive
+
+    if(failed)
+      test_output = "Failed Tests:\n"
+      tests = @failed_tests.select { |kvp| kvp[:dll] == test_dll }
+    elsif(passed)
+      return if @failed
+      test_output = "All Passed:\n"
+      tests = @passed_tests.select { |kvp| kvp[:dll] == test_dll }
+    else
+      test_output = "Test Inconclusive:\nNo tests found under #{ test_name }\n"
+    end
+    
+    current_spec = ""
+
+    first_test = true
+
+    tests.each do |line|
+      test_output += "\n" unless first_test
+      first_test = false
+      test_output += line[:name] + "\n"
+      test_output += line[:errormessage].strip + "\n" if line[:errormessage] and line[:errormessage].length > 0
+
+      if(failed && @first_failed_test == nil && line[:errormessage])
+        @first_failed_test = test_output
+      end
+    end
+
+    @test_results += test_output + "\n"
+
+    puts @test_results
+  end
+
+  def execute test_name
+    @test_results = ""
+    @failed_tests = Array.new
+    @passed_tests = Array.new
+    @status_by_dll.clear
+    @first_failed_test = nil
+
+    test_dlls.each do |test_dll|
+      test_output = @sh.execute "#{test_cmd(test_dll, test_name)}"
+  
+      set_test_status test_dll, test_output
+      puts 'Test Name : ' + test_name
+      parse_test_result test_dll, test_output, test_name
+    end
+
+    @inconclusive = true
+    @failed = false
+
+    @status_by_dll.each_value do |value|
+      @inconclusive = @inconclusive && value[:inconclusive]
+      @failed = @failed || value[:failed]
+    end
+
+    test_dlls.each do |test_dll|
+      set_test_result_output test_dll, test_name
+    end
+
+    if(!@inconclusive && !@failed)
+      @test_results += "#{@passed_tests.count} tests ran and passed\n"
+    end
+
+    @test_results
+  end
+  
+  def test_cmd test_dll, test_name
+    if test_name
+      return "\"#{MSPECTestRunner.mspec_path}\" #{test_dll}"
+    else
+      return "\"#{MSPECTestRunner.mspec_path}\" #{test_dll}"
+    end
+  end 
+  
+end
+
+
 
 class CommandShell
   def execute cmd

--- a/watcher_dot_net.rb
+++ b/watcher_dot_net.rb
@@ -2,7 +2,6 @@
 #http://www.github.com/amirrajan/specwatchr
 #Copyright (c) 2011 Amir Rajan, Matt Florence
 #Copyright (c) 2011 The NSpec Development Team
-require 'pry'
 class GrowlNotifier
   def self.growl_path
     @@growl_path


### PR DESCRIPTION
Added Machine.Specifications as an additional test_runner in dotnet.watchr.rb.
Implemented the new MSPECTestRunner inside of watcher_dot_net.rb

![image](https://f.cloud.github.com/assets/1062417/378186/89990734-a522-11e2-94db-783e0fdd875b.png)

I hope this helps some folks that want to use Machine.Specifications with SpecWatchr.

I would love some feedback with how I implemented the runner as i'm quite new to ruby.