### PR TITLE
fix dll detection loop for specrunner

### DIFF
--- a/watcher_dot_net.rb
+++ b/watcher_dot_net.rb
@@ -222,11 +222,15 @@ class NSpecRunner < TestRunner
 
   def contained_in_test_project file
     found = false
-    test_dlls.each do |dll|
-      found = true if root_folder(dll) == root_folder(file)
+	test_dlls.each do |dll|
+      if(found)
+	   break
+	  else 
+		  found = root_folder(dll) == root_folder(file)
+	  end
     end
 
-    found
+    return found
   end
 
   def self.nspec_path


### PR DESCRIPTION
When watching multiple projects, specrunner was returning from the loop in the first iteration. now it will loop until found, or nothing is found in the entire project array.